### PR TITLE
Fix story titles with apostrophes cutting off

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -19,7 +19,7 @@ function removeButtons(container) {
  */
 function addButtons(copyLinkButton) {
     const story = copyLinkButton.closest("form.story.model")
-    const storyName = story.querySelector("fieldset.name [name='story[name]']").value;
+    const storyName = story.querySelector("fieldset.name [name='story[name]']").value.replace(/'/g, '’');
     const storyUrl = copyLinkButton.getAttribute('data-clipboard-text');
     const storyMdLink = makeMdLink(storyName, storyUrl);
 


### PR DESCRIPTION
Fix: A story title like the following would cut off at the apostrophe:

> [UX Bug] Members don't know they can click on rows in tables

The simplest solution is to replace straight apostrophes with smart ones. I have not looked at the Pivotal source code to find out why straight apostrophes are not accepted as part of `data-clipboard-text`.